### PR TITLE
Split if (A.and.B) into two if statements

### DIFF
--- a/src/cpl_mct/wav_comp_mct.F90
+++ b/src/cpl_mct/wav_comp_mct.F90
@@ -758,10 +758,16 @@ CONTAINS
       call seq_timemgr_EClockGetData( EClock, prev_ymd=ymd, prev_tod=tod )
 
       ! QL, 171107, output every outfreq hours
-      if (outfreq .gt. 0 .and. mod(hh, outfreq) .eq. 0 ) then
-          histwr = .true.
-      else
-          histwr = seq_timemgr_historyAlarmIsOn(EClock)
+      histwr = seq_timemgr_historyAlarmIsOn(EClock)
+      if (outfreq .gt. 0) then
+          ! MNL, 200626: gfortran 9.1  was computing mod(hh, outfreq) even when
+          !              it was the second term in an .and. with the first term
+          !              evaluating to .false.; running CESM with DEBUG=TRUE,
+          !              this caused a divide-by-zero error. Splitting the if
+          !              avoids that abort.
+          if (mod(hh, outfreq) .eq. 0 ) then
+              histwr = .true.
+          end if
       end if
 
 


### PR DESCRIPTION
### Description of changes:

With gfortran 9.1, "if (A.and.B)" evaluates B even if A is false. When running
CESM with DEBUG=TRUE, this behavior leads to a divide-by-zero error when A is
checking if the denominator of a term in B is non-zero.

### Testing:
 
Test case/suite: I ran `aux_pop_MARBL` test suite on cheyenne with both `intel` and `gnu`, generating baselines with master branch of ww3 and comparing with this branch
Test status: all `cheyenne_intel` tests were bfb; the non-debug `cheyenne_gnu` tests were also bfb. `cheyenne_gnu` tests with `DEBUG=TRUE` failed in the baseline runs but ran successfully with this branch.

Fixes #3 

User interface (namelist or namelist defaults) changes?

None
