### PR TITLE
Add the gx1v7 grid input files

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -167,6 +167,8 @@ def buildnml(case, caseroot, compname):
     # currently only ww3a and wtx0.66v1 are supported
     if wav_grid == "ww3a":
         mod_def_in = os.path.join(din_loc_root, "wav", "ww3", "ww3a.mod_def.wwver7.14.220119")
+    elif wav_grid == "gx1v7":
+        mod_def_in = os.path.join(din_loc_root, "wav", "ww3", "gx1v7.mod_def.ww3.wwver7.14.220328")
     elif wav_grid == "wtx0.66v1":
         mod_def_in = os.path.join(din_loc_root, "wav", "ww3", "wt061.mod_def.ww3.wwver7.14.220110")
     else:

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -37,8 +37,8 @@
       <!-- The following four files are for wwver 6.07 and will not be compatible with wwver 7.14 -->
       <value runtype="startup" wav_grid="ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.restart.ww3.calm.wwver7.14.220119</value>
       <value runtype="hybrid" wav_grid="ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.restart.ww3.calm.wwver7.14.220119</value>
-      <!-- <value runtype="startup" wav_grid="gx1v7">/glade/scratch/hkershaw/wwatch3v6p07/IC4M3IS0k_gx17/restart.ww3</value> -->
-      <!-- <value runtype="hybrid" wav_grid="gx1v7">/glade/scratch/hkershaw/wwatch3v6p07/IC4M3IS0k_gx17/restart.ww3</value> -->
+      <value runtype="startup" wav_grid="gx1v7">$DIN_LOC_ROOT/wav/ww3/gx1v7.restart.ww3.calm.wwver7.14.220328</value>
+      <value runtype="hybrid" wav_grid="gx1v7">$DIN_LOC_ROOT/wav/ww3/gx1v7.restart.ww3.calm.wwver7.14.220328</value>
       <value runtype="startup" wav_grid="wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/wt061.restart.ww3.calm.wwver7.14.220110</value>
       <value runtype="hybrid" wav_grid="wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/wt061.restart.ww3.calm.wwver7.14.220110</value>
     </values>


### PR DESCRIPTION
### Description of changes:

Adds the POP2 gx1v7 grid input files for ww3dev.

### Testing:
 
Test case/suite: ERS.f09_g17_wg17.1850_CAM60_CLM50%BGC-CROP_CICE6_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3DEV_BGC%BDRD.cheyenne_intel
Test status: all pass

