### PR TITLE
reorder initialization to accomidate async io

### DIFF
--- a/src/cpl_nuopc/wav_shr_methods.F90
+++ b/src/cpl_nuopc/wav_shr_methods.F90
@@ -128,6 +128,8 @@ contains
 !===============================================================================
 
   subroutine set_component_logging(gcomp, mastertask, logunit, shrlogunit, rc)
+    use NUOPC, only : NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
+    use ESMF, only  : ESMF_GridCompGet, ESMF_LOGMSG_INFO, ESMF_LogWrite
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -138,7 +140,9 @@ contains
 
     ! local variables
     character(len=CL) :: diro
+    character(len=CL) :: name
     character(len=CL) :: logfile
+    character(len=*), parameter :: subname = "("//__FILE__//":set_component_logging)"
     !-----------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -155,8 +159,18 @@ contains
     else
        logUnit = 6
     endif
-
+    ! TODO: deprecaated and should be removed
     call shr_file_setLogUnit (logunit)
+
+    call ESMF_GridCompGet(gcomp, name=name, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_LogWrite(trim(subname)//": setting logunit for component: "//trim(name), ESMF_LOGMSG_INFO)
+
+    call NUOPC_CompAttributeAdd(gcomp, attrList=(/'logunit'/), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call NUOPC_CompAttributeSet(gcomp, name='logunit',value=logunit, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine set_component_logging
 


### PR DESCRIPTION
### Description of changes:

Minor reordering of initialization for IO.

### Testing:
 cesm prealpha tests on cheyenne
Test case/suite: cesm2_3_alpha09c

Test status: bit for bit

Fixes [WW3 Github issue #]

User interface (namelist or namelist defaults) changes?

